### PR TITLE
use correct delay for MPDStandAloneMonitor

### DIFF
--- a/src/main/java/org/bff/javampd/monitor/MPDStandAloneMonitor.java
+++ b/src/main/java/org/bff/javampd/monitor/MPDStandAloneMonitor.java
@@ -54,7 +54,7 @@ public class MPDStandAloneMonitor
 
         this.standAloneMonitorThread = new StandAloneMonitorThread(serverStatus,
                 connectionMonitor,
-                monitorProperties.getConnectionDelay(),
+                monitorProperties.getMonitorDelay(),
                 monitorProperties.getExceptionDelay());
         createMonitors();
     }


### PR DESCRIPTION
I assume the wrong delay is used in the MPDStandAloneMonitor.