### PR TITLE
Added more status codes to mute warnings

### DIFF
--- a/src/main/java/org/bff/javampd/server/Status.java
+++ b/src/main/java/org/bff/javampd/server/Status.java
@@ -127,7 +127,7 @@ public enum Status {
                 return status;
             }
         }
-        //LOGGER.warn("Unknown status {} returned", statusLine);
+        LOGGER.warn("Unknown status {} returned", statusLine);
         return UNKNOWN;
     }
 }

--- a/src/main/java/org/bff/javampd/server/Status.java
+++ b/src/main/java/org/bff/javampd/server/Status.java
@@ -65,6 +65,26 @@ public enum Status {
      */
     ERROR("error:"),
     /**
+     *  the threshold at which songs will be overlapped. Like crossfading but doesn't fade the track volume, just overlaps
+     */
+    MIXRAMPDB("mixrampdb:"),
+    /**
+     *  The index of the next song in the queue
+     */
+    NEXTSONG("nextsong:"),
+    /**
+     *  The id of the next song
+     */
+    NEXTSONGID("nextsongid:"),
+    /**
+     *  Whether the server should consume the message in queue or not
+     */
+    CONSUME("consume:"),
+    /**
+     *  whether we should just replay this song repeatively
+     */
+    SINGLE("single:"),
+    /**
      * if the status is unknown
      */
     UNKNOWN("");
@@ -107,7 +127,7 @@ public enum Status {
                 return status;
             }
         }
-        LOGGER.warn("Unknown status {} returned", statusLine);
+        //LOGGER.warn("Unknown status {} returned", statusLine);
         return UNKNOWN;
     }
 }


### PR DESCRIPTION
I got a lot of warnings when using the monitor because the org.bff.javampd.server.Status lacked some different status codes. These are now added so i wont have that many warnings...

Please accept it :heart: 