### PR TITLE
escape single quote when performing search and find

### DIFF
--- a/src/main/java/org/bff/javampd/command/MPDCommandExecutor.java
+++ b/src/main/java/org/bff/javampd/command/MPDCommandExecutor.java
@@ -52,7 +52,7 @@ public class MPDCommandExecutor implements CommandExecutor {
   public synchronized List<String> sendCommand(MPDCommand command) {
     try {
       checkSocket();
-      log.debug(String.format("Sending command: %s", command));
+      log.debug("Sending command: {}", command);
       return new ArrayList<>(mpdSocket.sendCommand(command));
     } catch (MPDSecurityException se) {
       LOGGER.warn(

--- a/src/main/java/org/bff/javampd/song/MPDSongSearcher.java
+++ b/src/main/java/org/bff/javampd/song/MPDSongSearcher.java
@@ -81,10 +81,14 @@ public class MPDSongSearcher implements SongSearcher {
   }
 
   private static String generateFindParams(ScopeType scopeType, String criteria) {
-    return String.format("(%s == '%s')", scopeType.getType(), criteria);
+    return String.format("(%s == '%s')", scopeType.getType(), escape(criteria));
   }
 
   private static String generateSearchParams(ScopeType scopeType, String criteria) {
-    return String.format("(%s contains '%s')", scopeType.getType(), criteria);
+    return String.format("(%s contains '%s')", scopeType.getType(), escape(criteria));
+  }
+
+  private static String escape(String s) {
+    return s.replace("'", "\\\\'");
   }
 }

--- a/src/test/java/org/bff/javampd/server/MPDSocketTest.java
+++ b/src/test/java/org/bff/javampd/server/MPDSocketTest.java
@@ -341,6 +341,21 @@ class MPDSocketTest {
   }
 
   @Test
+  void ping() throws IOException {
+    createValidSocket();
+
+    when(mockedBufferedReader.readLine()).thenReturn("OK");
+
+    MPDCommand command = new MPDCommand("status");
+    mockedOutputStream = mock(OutputStream.class);
+    when(mockSocket.getOutputStream()).thenReturn(mockedOutputStream);
+    socket.sendCommand(command);
+    verify(mockedOutputStream, times(2)).write(byteArgumentCaptor.capture());
+
+    assertArrayEquals("ping\n".getBytes(), byteArgumentCaptor.getAllValues().get(0));
+  }
+
+  @Test
   void testSendCommandsExtraResponses() throws IOException {
     createValidSocket();
 


### PR DESCRIPTION
# Pull Request Template

## Escape single quote when performing search and find

Fixes #93 

## Checklist:

- [X] follows style guidelines (run mvn spotless:apply to format the code)
- [X] commented my code in hard-to-understand areas
- [X] made corresponding changes to the documentation
- [X] validated static analysis
- [X] added tests that prove my fix or feature works
