### PR TITLE
listPlaylistSongs() throws an IndexOutOfBoundsException if a track is

### DIFF
--- a/src/main/java/org/bff/javampd/playlist/MPDPlaylistDatabase.java
+++ b/src/main/java/org/bff/javampd/playlist/MPDPlaylistDatabase.java
@@ -4,29 +4,36 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.bff.javampd.command.CommandExecutor;
 import org.bff.javampd.database.DatabaseProperties;
+import org.bff.javampd.database.MusicDatabase;
 import org.bff.javampd.database.TagLister;
+import org.bff.javampd.server.MPD;
 import org.bff.javampd.song.MPDSong;
 import org.bff.javampd.song.SongConverter;
 import org.bff.javampd.song.SongDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * MPDPlaylistDatabase represents a playlist database to a {@link org.bff.javampd.server.MPD}. To
- * obtain an instance of the class you must use the {@link
- * org.bff.javampd.database.MusicDatabase#getPlaylistDatabase()} method from the {@link
- * org.bff.javampd.server.MPD} connection class.
+ * MPDPlaylistDatabase represents a playlist database to a {@link MPD}. To obtain an instance of the
+ * class you must use the {@link MusicDatabase#getPlaylistDatabase()} method from the {@link MPD}
+ * connection class.
  *
  * @author Bill
  */
 public class MPDPlaylistDatabase implements PlaylistDatabase {
+
   private final SongDatabase songDatabase;
   private final CommandExecutor commandExecutor;
   private final DatabaseProperties databaseProperties;
   private final TagLister tagLister;
   private final SongConverter songConverter;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MPDPlaylistDatabase.class);
 
   @Inject
   public MPDPlaylistDatabase(
@@ -69,7 +76,19 @@ public class MPDPlaylistDatabase implements PlaylistDatabase {
 
     List<MPDSong> songList =
         songConverter.getSongFileNameList(response).stream()
-            .map(song -> new ArrayList<>(songDatabase.searchFileName(song)).get(0))
+            .map(
+                song -> {
+                  Optional<MPDSong> mpdSong = Optional.empty();
+                  try {
+                    mpdSong =
+                        Optional.of(new ArrayList<>(songDatabase.searchFileName(song)).get(0));
+                  } catch (IndexOutOfBoundsException e) {
+                    LOGGER.error("Could not find file: {}", song);
+                  }
+                  return mpdSong;
+                })
+            .filter(Optional::isPresent)
+            .map(Optional::get)
             .collect(Collectors.toList());
 
     // Handle web radio streams


### PR DESCRIPTION
I ran into an error where `MPDPlaylistDatabase.listPlaylistSongs()` ran into an `IndexOutOfBoundsException`:

```java
new ArrayList<>(songDatabase.searchFileName(song)).get(0)
```

This happened because of a track with a `/` (slash) in its title. Somehow, `mpd` saved it under a wrong filename. The filename had a ` ` space instead of the slash and `mpd` ignored that character completely.

Anyway, instead of breaking down, this patch just ignores the file which was not found.