### PR TITLE
[7.x] Fix album group parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.inthebacklog</groupId>
     <artifactId>javampd</artifactId>
     <packaging>jar</packaging>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>7.3.1</version>
     <name>JavaMPD</name>
     <description>A Java API for controlling the Music Player Daemon (MPD)</description>
     <url>https://github.com/finnyb/javampd/</url>

--- a/src/main/java/org/bff/javampd/album/AlbumConverter.java
+++ b/src/main/java/org/bff/javampd/album/AlbumConverter.java
@@ -14,7 +14,7 @@ public interface AlbumConverter {
    * Converts the response from the MPD server into a {@link MPDAlbum} object.
    *
    * @param list the response from the MPD server
-   * @return a {@link MPDAlbum} object
+   * @return a collection of {@link MPDAlbum} objects
    */
   Collection<MPDAlbum> convertResponseToAlbum(List<String> list);
 }

--- a/src/main/java/org/bff/javampd/album/MPDAlbum.java
+++ b/src/main/java/org/bff/javampd/album/MPDAlbum.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 
 /**
  * MPDAlbum represents an album
@@ -14,7 +13,7 @@ import lombok.NonNull;
 @Builder(builderMethodName = "internalBuilder")
 @Data
 public class MPDAlbum implements Comparable<MPDAlbum> {
-  @NonNull private String name;
+  private String name;
   private String albumArtist;
   @Builder.Default private List<String> artistNames = new ArrayList<>();
   @Builder.Default private List<String> dates = new ArrayList<>();

--- a/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
+++ b/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
@@ -11,18 +11,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MPDAlbumConverter implements AlbumConverter {
 
-  private static final String DELIMITING_PREFIX = AlbumProcessor.getDelimitingPrefix();
-
   @Override
   public Collection<MPDAlbum> convertResponseToAlbum(List<String> list) {
     var hashMap = new LinkedHashMap<String, MPDAlbum>();
     Iterator<String> iterator = list.iterator();
 
-    var artists = new ArrayList<String>();
-    var genres = new ArrayList<String>();
-    var dates = new ArrayList<String>();
+    List<String> artists = new ArrayList<>();
+    List<String> genres = new ArrayList<>();
+    String date = null;
     String albumArtist = null;
-    var album = "";
+    String albumName = "";
 
     String line;
     while (iterator.hasNext()) {
@@ -32,51 +30,46 @@ public class MPDAlbumConverter implements AlbumConverter {
       if (albumProcessor != null) {
         var tag = albumProcessor.getProcessor().processTag(line);
         switch (albumProcessor.getProcessor().getType()) {
-          case ALBUM:
-            album = tag;
-            break;
           case ALBUM_ARTIST:
             albumArtist = tag;
+            artists = new ArrayList<>();
+            date = null;
+            genres = new ArrayList<>();
+            break;
+          case GENRE:
+            genres.add(tag);
+            artists = new ArrayList<>();
+            date = null;
+            break;
+          case DATE:
+            date = tag;
+            artists = new ArrayList<>();
             break;
           case ARTIST:
             artists.add(tag);
             break;
-          case GENRE:
-            genres.add(tag);
-            break;
-          case DATE:
-            dates.add(tag);
+          case ALBUM:
+            albumName = tag;
+            if (albumArtist != null && !albumArtist.isBlank() && !albumName.isBlank() && date != null && !date.isEmpty()) {
+                String mapKey = String.format("%s - %s [%s]", albumArtist, albumName, date);
+                MPDAlbum a = hashMap.get(mapKey);
+                if (a == null) {
+                    hashMap.put(mapKey,
+                        MPDAlbum.builder(albumName)
+                            .albumArtist(albumArtist)
+                            .artistNames(artists)
+                            .genres(genres)
+                            .dates(new ArrayList<>(List.of(date)))
+                            .build());
+                }
+            }
             break;
           default:
-            log.warn("Unprocessed album type {} found.", tag);
+            log.warn("Unprocessed albumName type {} found.", tag);
             break;
         }
       } else {
         log.warn("Processor not found - {}", line);
-      }
-
-      if (line.startsWith(DELIMITING_PREFIX)) {
-        var a = hashMap.get(album);
-        if (a == null) {
-          hashMap.put(
-              album,
-              MPDAlbum.builder(album)
-                  .albumArtist(albumArtist)
-                  .artistNames(artists)
-                  .genres(genres)
-                  .dates(dates)
-                  .build());
-        } else {
-          a.addArtists(artists);
-          a.addGenres(genres);
-          a.addDates(dates);
-        }
-
-        artists = new ArrayList<>();
-        genres = new ArrayList<>();
-        dates = new ArrayList<>();
-        albumArtist = null;
-        album = "";
       }
     }
 

--- a/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
+++ b/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
@@ -1,7 +1,10 @@
 package org.bff.javampd.album;
 
+import static org.bff.javampd.processor.ResponseProcessor.TagType.ALBUM;
+
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
+import org.bff.javampd.processor.ResponseProcessor;
 
 /**
  * Converts a response from the server to an {@link MPDAlbum}
@@ -16,11 +19,7 @@ public class MPDAlbumConverter implements AlbumConverter {
     var hashMap = new LinkedHashMap<String, MPDAlbum>();
     Iterator<String> iterator = list.iterator();
 
-    List<String> artists = new ArrayList<>();
-    List<String> genres = new ArrayList<>();
-    String date = null;
-    String albumArtist = null;
-    String albumName = "";
+    MPDAlbum.MPDAlbumBuilder albumBuilder = new MPDAlbum.MPDAlbumBuilder();
 
     String line;
     while (iterator.hasNext()) {
@@ -28,50 +27,21 @@ public class MPDAlbumConverter implements AlbumConverter {
 
       var albumProcessor = AlbumProcessor.lookup(line);
       if (albumProcessor != null) {
-        var tag = albumProcessor.getProcessor().processTag(line);
-        switch (albumProcessor.getProcessor().getType()) {
-          case ALBUM_ARTIST:
-            albumArtist = tag;
-            artists = new ArrayList<>();
-            date = null;
-            genres = new ArrayList<>();
-            break;
-          case GENRE:
-            genres.add(tag);
-            artists = new ArrayList<>();
-            date = null;
-            break;
-          case DATE:
-            date = tag;
-            artists = new ArrayList<>();
-            break;
-          case ARTIST:
-            artists.add(tag);
-            break;
-          case ALBUM:
-            albumName = tag;
-            if (albumArtist != null
-                && !albumArtist.isBlank()
-                && !albumName.isBlank()
-                && date != null
-                && !date.isEmpty()) {
-              String mapKey = String.format("%s - %s [%s]", albumArtist, albumName, date);
-              MPDAlbum a = hashMap.get(mapKey);
-              if (a == null) {
-                hashMap.put(
-                    mapKey,
-                    MPDAlbum.builder(albumName)
-                        .albumArtist(albumArtist)
-                        .artistNames(artists)
-                        .genres(genres)
-                        .dates(new ArrayList<>(List.of(date)))
-                        .build());
-              }
-            }
-            break;
-          default:
-            log.warn("Unprocessed albumName type {} found.", tag);
-            break;
+        var tagType = albumProcessor.getProcessor().getType();
+        var tagValue = albumProcessor.getProcessor().processTag(line);
+        albumBuilder = mergeTag(albumBuilder, tagType, tagValue);
+        if (tagType == ALBUM) {
+          MPDAlbum album = albumBuilder.build();
+          if (album.getAlbumArtist() != null
+              && album.getName() != null
+              && album.getDates() != null
+              && !album.getDates().isEmpty()) {
+            String mapKey =
+                String.format(
+                    "%s - %s [%s]",
+                    album.getAlbumArtist(), album.getName(), album.getDates().get(0));
+            hashMap.putIfAbsent(mapKey, album);
+          }
         }
       } else {
         log.warn("Processor not found - {}", line);
@@ -79,5 +49,61 @@ public class MPDAlbumConverter implements AlbumConverter {
     }
 
     return hashMap.values();
+  }
+
+  /**
+   * Integrates the provided tag into the MPDAlbumBuilder.
+   *
+   * <p>It is assumed that all album metadata is grouped hierarchically in this (descending) order:
+   *
+   * <ol>
+   *   <li>{@link ResponseProcessor.TagType#ALBUM_ARTIST}
+   *   <li>{@link ResponseProcessor.TagType#GENRE}
+   *   <li>{@link ResponseProcessor.TagType#DATE}
+   *   <li>{@link ResponseProcessor.TagType#ARTIST}
+   *   <li>{@link ResponseProcessor.TagType#ALBUM}
+   * </ol>
+   *
+   * <p>Any tag that exists in higher levels of the hierarchy implies erasure of lower-hierarchy
+   * tags.
+   *
+   * @param accumulator The current album builder instance.
+   * @param tagValue The extracted, parsed value for the tag
+   * @param tagType The type of tag
+   * @return A reference to the builder provided as parameter, updated according to the rest of the
+   *     supplied parameters plus the assumptions explained above.
+   */
+  private static MPDAlbum.MPDAlbumBuilder mergeTag(
+      MPDAlbum.MPDAlbumBuilder accumulator, ResponseProcessor.TagType tagType, String tagValue) {
+    MPDAlbum cachedResult = accumulator.build();
+    return switch (tagType) {
+      case ALBUM_ARTIST -> accumulator
+          .albumArtist(tagValue)
+          .genres(new ArrayList<>())
+          .dates(new ArrayList<>())
+          .artistNames(new ArrayList<>())
+          .name(null);
+      case GENRE -> {
+        cachedResult.addGenre(tagValue);
+        yield accumulator
+            .genres(cachedResult.getGenres())
+            .dates(new ArrayList<>())
+            .artistNames(new ArrayList<>())
+            .name(null);
+      }
+      case DATE -> accumulator
+          .dates(new ArrayList<>(List.of(tagValue)))
+          .artistNames(new ArrayList<>())
+          .name(null);
+      case ARTIST -> {
+        cachedResult.addArtist(tagValue);
+        yield accumulator.artistNames(cachedResult.getArtistNames()).name(null);
+      }
+      case ALBUM -> accumulator.name(tagValue);
+      default -> {
+        log.warn("Unprocessed tagValue type {} found.", tagValue);
+        yield accumulator;
+      }
+    };
   }
 }

--- a/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
+++ b/src/main/java/org/bff/javampd/album/MPDAlbumConverter.java
@@ -50,18 +50,23 @@ public class MPDAlbumConverter implements AlbumConverter {
             break;
           case ALBUM:
             albumName = tag;
-            if (albumArtist != null && !albumArtist.isBlank() && !albumName.isBlank() && date != null && !date.isEmpty()) {
-                String mapKey = String.format("%s - %s [%s]", albumArtist, albumName, date);
-                MPDAlbum a = hashMap.get(mapKey);
-                if (a == null) {
-                    hashMap.put(mapKey,
-                        MPDAlbum.builder(albumName)
-                            .albumArtist(albumArtist)
-                            .artistNames(artists)
-                            .genres(genres)
-                            .dates(new ArrayList<>(List.of(date)))
-                            .build());
-                }
+            if (albumArtist != null
+                && !albumArtist.isBlank()
+                && !albumName.isBlank()
+                && date != null
+                && !date.isEmpty()) {
+              String mapKey = String.format("%s - %s [%s]", albumArtist, albumName, date);
+              MPDAlbum a = hashMap.get(mapKey);
+              if (a == null) {
+                hashMap.put(
+                    mapKey,
+                    MPDAlbum.builder(albumName)
+                        .albumArtist(albumArtist)
+                        .artistNames(artists)
+                        .genres(genres)
+                        .dates(new ArrayList<>(List.of(date)))
+                        .build());
+              }
             }
             break;
           default:

--- a/src/test/java/org/bff/javampd/album/MPDAlbumConverterTest.java
+++ b/src/test/java/org/bff/javampd/album/MPDAlbumConverterTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -80,24 +81,30 @@ class MPDAlbumConverterTest {
   void clearAttributes() {
     var response =
         Arrays.asList(
-            "AlbumArtist: Spiritbox",
-            "Genre: Metal",
-            "Date: 2021",
-            "Artist: Spiritbox",
-            "Album: Eternal Blue",
-            "Artist: Tool",
-            "Album: Lateralus");
+            "AlbumArtist: Faith No More",
+            "Genre: Alternative Metal",
+            "Date: 1989",
+            "Artist: Faith No More",
+            "Album: The Real Thing",
+            "Date: 1997-06-03",
+            "Artist: Faith No More",
+            "Album: Album of the Year",
+            "Date: 1999",
+            "Artist: Faith No More",
+            "Album: Angel Dust",
+            "Album: King for a Day... Fool for a Lifetime");
 
     var albums = new ArrayList<>(converter.convertResponseToAlbum(response));
-    var a = albums.get(1);
-
-    assertAll(
-        () -> assertThat(a.getName(), is(equalTo("Lateralus"))),
-        () -> assertNull(a.getAlbumArtist()),
-        () -> assertThat(a.getArtistNames().size(), is(equalTo(1))),
-        () -> assertThat(a.getArtistNames().get(0), is(equalTo("Tool"))),
-        () -> assertThat(a.getGenres().size(), is(equalTo(0))),
-        () -> assertThat(a.getDates().size(), is(equalTo(0))));
+    assertThat(albums.size(), is(4));
+    for (MPDAlbum a : albums) {
+        assertAll(
+            () -> assertThat(a.getAlbumArtist(), is("Faith No More")),
+            () -> assertThat(a.getArtistNames().size(), is(1)),
+            () -> assertThat(a.getArtistNames().get(0), is("Faith No More")),
+            () -> assertThat(a.getGenres().size(), is(1)),
+            () -> assertThat(a.getGenres().get(0), is("Alternative Metal")),
+            () -> assertThat(a.getDates().size(), is(1)));
+    }
   }
 
   @Test
@@ -126,5 +133,33 @@ class MPDAlbumConverterTest {
         () -> assertThat(a.getGenres().get(0), is(equalTo("Metal"))),
         () -> assertThat(a.getDates().size(), is(equalTo(1))),
         () -> assertThat(a.getDates().get(0), is(equalTo("2021"))));
+  }
+
+  @Test
+  void multipleAlbums_FromSameGroupOf_AlbumArtist_Genre_Date_Artist() {
+    var response =
+        Arrays.asList(
+            "AlbumArtist: Black Sabbath",
+            "Genre: Metal",
+            "Date: 1970",
+            "Artist: Black Sabbath",
+            "Album: Black Sabbath",
+            "Album: Paranoid");
+
+    var albums = new ArrayList<>(converter.convertResponseToAlbum(response));
+    var a1 = albums.get(0);
+    var a2 = albums.get(1);
+
+    assertAll(
+        () -> assertThat(a1.getAlbumArtist(), is("Black Sabbath")),
+        () -> assertThat(a1.getArtistNames().get(0), is("Black Sabbath")),
+        () -> assertThat(a1.getGenres().get(0), is("Metal")),
+        () -> assertThat(a1.getDates().get(0), is("1970")),
+        () -> assertThat(a1.getName(), is("Black Sabbath")),
+        () -> assertThat(a2.getAlbumArtist(), is(a1.getAlbumArtist())),
+        () -> assertThat(a2.getArtistNames(), is(a1.getArtistNames())),
+        () -> assertThat(a2.getGenres(), is(a1.getGenres())),
+        () -> assertThat(a2.getDates(), is(a1.getDates())),
+        () -> assertThat(a2.getName(), is("Paranoid")));
   }
 }

--- a/src/test/java/org/bff/javampd/album/MPDAlbumConverterTest.java
+++ b/src/test/java/org/bff/javampd/album/MPDAlbumConverterTest.java
@@ -4,12 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -97,13 +95,13 @@ class MPDAlbumConverterTest {
     var albums = new ArrayList<>(converter.convertResponseToAlbum(response));
     assertThat(albums.size(), is(4));
     for (MPDAlbum a : albums) {
-        assertAll(
-            () -> assertThat(a.getAlbumArtist(), is("Faith No More")),
-            () -> assertThat(a.getArtistNames().size(), is(1)),
-            () -> assertThat(a.getArtistNames().get(0), is("Faith No More")),
-            () -> assertThat(a.getGenres().size(), is(1)),
-            () -> assertThat(a.getGenres().get(0), is("Alternative Metal")),
-            () -> assertThat(a.getDates().size(), is(1)));
+      assertAll(
+          () -> assertThat(a.getAlbumArtist(), is("Faith No More")),
+          () -> assertThat(a.getArtistNames().size(), is(1)),
+          () -> assertThat(a.getArtistNames().get(0), is("Faith No More")),
+          () -> assertThat(a.getGenres().size(), is(1)),
+          () -> assertThat(a.getGenres().get(0), is("Alternative Metal")),
+          () -> assertThat(a.getDates().size(), is(1)));
     }
   }
 


### PR DESCRIPTION
Resolves #257

(tested running MPD v0.24.6)

## Description

Updates the algorithm to correctly parse groups when querying a list of albums from the mpd socket. Basically, it should ensure that more than 1 album in the same artist/date/genre/albumartist group will be included in the final album object list, without missing any tags.

Please review my "Black Sabbath" and "Faith No More" test cases that exemplify a bigger list of offenders I personally had when using javampd. I have reissue CDs and I tag my music using MusicBrainz; if some dates may not appear to be chronologically correct according to any artist's discography pages across the internet, this is the reason why.

I submitted these to be merged on this specific branch because it is linked to the most recent release, but more importantly because it's the one we use over at rain0r's [ampd client project](https://github.com/rain0r/ampd).

I gladly will make any changes so that this PR may be merged into a "7.x support" branch, or whatever one we can coincide in. Thanks in advance.

On a sidenote, I know for a fact that these commits will have no conflicts if merged against the current `develop` branch.

## Checklist:

- [x] follows style guidelines (run mvn spotless:apply to format the code)
- [x] commented my code in hard-to-understand areas
- [ ] made corresponding changes to the documentation
- [ ] validated static analysis
- [x] added tests that prove my fix or feature works